### PR TITLE
feat: adds pt-BR language support

### DIFF
--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,0 +1,11 @@
+{
+  "DND5E.CustomSkills": "Perícias Personalizadas",
+  "DND5E.CustomSkills.Settings.CustomSkills": "Perícias Personalizadas",
+  "DND5E.CustomSkills.Settings.CustomSkillsHint": "Defina as perícias adicionais que você deseja adicionar. Use uma lista separada por vírgulas. Exemplo: \"Intuição, Sobrevivência Urbana\".",
+  "DND5E.CustomSkills.Settings.HideEmptySkills": "Ocultar Perícias Vazias",
+  "DND5E.CustomSkills.Settings.HideEmptySkillsHint": "Se ativado, as perícias personalizadas que tiverem valor zero serão ocultadas na ficha do personagem.",
+  "DND5E.CustomSkills.AbilityCheckWithSkill": "{skill} ({ability}) Teste",
+  "DND5E.CustomSkills.RollDialogSkillLabel": "Perícia",
+  "DND5E.CustomSkills.RollDialogSkillPrompt": "Selecione uma perícia para este teste.",
+  "DND5E.CustomSkills.RollSkill": "Rolar {skill}"
+}

--- a/module.json
+++ b/module.json
@@ -48,6 +48,11 @@
       "name": "Italiano",
       "path": "lang/it.json",
       "flags": {}
+    },
+    {
+      "lang": "pt-BR",
+      "name": "Português (Brasil)",
+      "path": "lang/pt-BR.json"
     }
   ]
 }


### PR DESCRIPTION
This PR adds support for the Portuguese (Brazil) (pt-BR) language to the module. Translations of key strings have been included in the lang/pt-BR.json file, and the language has been registered in module.json.

If needed, I can help expand or review more future translations.